### PR TITLE
fix `version` command not working correctly in the released binary

### DIFF
--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -165,17 +165,3 @@ tasks:
         sed "s/%%WINDOWS64_SHA%%/{{ .WINDOWS64_SHA }}/" |
         sed "s/%%WINDOWS64_SIZE%%/{{ .WINDOWS64_SIZE }}/" \
         > {{ .DIST_DIR }}/package_index.json
-
-vars:
-  LDFLAGS: >
-    -ldflags
-    '
-    -X github.com/arduino/arduino-fwuploader/version.versionString={{.VERSION}}
-    -X github.com/arduino/arduino-fwuploader/version.commit={{ .COMMIT }}
-    -X github.com/arduino/arduino-fwuploader/version.date={{.TIMESTAMP}}
-    '
-  VERSION: "{{ if .NIGHTLY }}nightly-{{ .TIMESTAMP_SHORT }}{{ else if .TAG }}{{ .TAG }}{{ else }}{{ .PACKAGE_NAME_PREFIX }}git-snapshot{{ end }}"
-  COMMIT:
-    sh: echo "$(git log -n 1 --format=%h)"
-  TIMESTAMP:
-    sh: echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -20,7 +20,7 @@ tasks:
       GO386: "softfloat"
     cmds:
       - |
-        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}.exe
+        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}.exe {{.LDFLAGS}}
         zip {{ .DIST_DIR}}/{{ .PACKAGE_NAME }} {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}.exe -j
         zip {{ .DIST_DIR}}/{{ .PACKAGE_NAME }} LICENSE.txt -r
     vars:
@@ -35,7 +35,7 @@ tasks:
       GOARCH: "amd64"
     cmds:
       - |
-        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}.exe
+        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}.exe {{.LDFLAGS}}
         zip {{ .DIST_DIR}}/{{ .PACKAGE_NAME }} {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}.exe -j
         zip {{ .DIST_DIR}}/{{ .PACKAGE_NAME }} LICENSE.txt -r
     vars:
@@ -51,7 +51,7 @@ tasks:
       GO386: "softfloat"
     cmds:
       - |
-        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}
+        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }} {{.LDFLAGS}}
         tar cj LICENSE.txt -C {{ .DIST_DIR}}/{{ .PLATFORM_DIR }} {{ .PROJECT_NAME }} -f {{ .DIST_DIR }}/{{ .PACKAGE_NAME }}
     vars:
       PLATFORM_DIR: "linux32"
@@ -65,7 +65,7 @@ tasks:
       GOARCH: "amd64"
     cmds:
       - |
-        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}
+        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }} {{.LDFLAGS}}
         tar cj LICENSE.txt -C {{ .DIST_DIR}}/{{ .PLATFORM_DIR }} {{ .PROJECT_NAME }} -f {{ .DIST_DIR }}/{{ .PACKAGE_NAME }}
     vars:
       PLATFORM_DIR: "linux64"
@@ -79,7 +79,7 @@ tasks:
       GOARCH: "arm"
     cmds:
       - |
-        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}
+        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }} {{.LDFLAGS}}
         tar cj LICENSE.txt -C {{ .DIST_DIR}}/{{ .PLATFORM_DIR }} {{ .PROJECT_NAME }} -f {{ .DIST_DIR }}/{{ .PACKAGE_NAME }}
     vars:
       PLATFORM_DIR: "linuxarm"
@@ -93,7 +93,7 @@ tasks:
       GOARCH: "arm64"
     cmds:
       - |
-        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}
+        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }} {{.LDFLAGS}}
         tar cj LICENSE.txt -C {{ .DIST_DIR}}/{{ .PLATFORM_DIR }} {{ .PROJECT_NAME }} -f {{ .DIST_DIR }}/{{ .PACKAGE_NAME }}
     vars:
       PLATFORM_DIR: "linuxarm64"
@@ -107,7 +107,7 @@ tasks:
       GOARCH: "amd64"
     cmds:
       - |
-        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }}
+        go build -o {{ .DIST_DIR}}/{{ .PLATFORM_DIR }}/{{ .PROJECT_NAME }} {{.LDFLAGS}}
         tar cj LICENSE.txt -C {{ .DIST_DIR}}/{{ .PLATFORM_DIR }} {{ .PROJECT_NAME }} -f {{ .DIST_DIR }}/{{ .PACKAGE_NAME }}
     vars:
       PLATFORM_DIR: "macos64"
@@ -165,3 +165,17 @@ tasks:
         sed "s/%%WINDOWS64_SHA%%/{{ .WINDOWS64_SHA }}/" |
         sed "s/%%WINDOWS64_SIZE%%/{{ .WINDOWS64_SIZE }}/" \
         > {{ .DIST_DIR }}/package_index.json
+
+vars:
+  LDFLAGS: >
+    -ldflags
+    '
+    -X github.com/arduino/arduino-fwuploader/version.versionString={{.VERSION}}
+    -X github.com/arduino/arduino-fwuploader/version.commit={{ .COMMIT }}
+    -X github.com/arduino/arduino-fwuploader/version.date={{.TIMESTAMP}}
+    '
+  VERSION: "{{ if .NIGHTLY }}nightly-{{ .TIMESTAMP_SHORT }}{{ else if .TAG }}{{ .TAG }}{{ else }}{{ .PACKAGE_NAME_PREFIX }}git-snapshot{{ end }}"
+  COMMIT:
+    sh: echo "$(git log -n 1 --format=%h)"
+  TIMESTAMP:
+    sh: echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"


### PR DESCRIPTION
We set variables containing information regarding version, commit and build time. These variables were set in the `Taskfile.yml` but not in the `DistTask.yml` (the one used in the CI)