### PR TITLE
fix uno wifi rev 2 not working

### DIFF
--- a/flasher/flasher.go
+++ b/flasher/flasher.go
@@ -64,7 +64,8 @@ type Flasher interface {
 
 // This matches the baudrate used in the FirmwareUpdater.ino sketch
 // https://github.com/arduino-libraries/WiFiNINA/blob/master/examples/Tools/FirmwareUpdater/FirmwareUpdater.ino
-const baudRate = 1000000
+// We used 1000000 before but it was causing problems on macOS with boards using true serial (AKA UNO WiFi rev2).
+const baudRate = 57600
 
 func openSerial(portAddress string) (serial.Port, error) {
 

--- a/flasher/flasher.go
+++ b/flasher/flasher.go
@@ -62,37 +62,24 @@ type Flasher interface {
 	sendCommand(data CommandData) error
 }
 
-// http://www.ni.com/product-documentation/54548/en/
-// Standard baud rates supported by most serial ports
-var baudRates = []int{
-	115200,
-	57600,
-	56000,
-	38400,
-}
+// This matches the baudrate used in the FirmwareUpdater.ino sketch
+// https://github.com/arduino-libraries/WiFiNINA/blob/master/examples/Tools/FirmwareUpdater/FirmwareUpdater.ino
+const baudRate = 1000000
 
 func openSerial(portAddress string) (serial.Port, error) {
-	var lastError error
 
-	for _, baudRate := range baudRates {
-		port, err := serial.Open(portAddress, &serial.Mode{BaudRate: baudRate})
-		if err != nil {
-			lastError = err
-			// Try another baudrate
-			continue
-		}
-		logrus.Infof("Opened port %s at %d", portAddress, baudRate)
-
-		if err := port.SetReadTimeout(30 * time.Second); err != nil {
-			err = fmt.Errorf("could not set timeout on serial port: %s", err)
-			logrus.Error(err)
-			return nil, err
-		}
-
-		return port, nil
+	port, err := serial.Open(portAddress, &serial.Mode{BaudRate: baudRate})
+	if err != nil {
+		return nil, err
 	}
+	logrus.Infof("Opened port %s at %d", portAddress, baudRate)
 
-	return nil, lastError
+	if err := port.SetReadTimeout(30 * time.Second); err != nil {
+		err = fmt.Errorf("could not set timeout on serial port: %s", err)
+		logrus.Error(err)
+		return nil, err
+	}
+	return port, nil
 }
 
 type FlashResult struct {

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/arduino/arduino-fwuploader
 
 go 1.14
 
-// branch with support for serial timeouts
-replace go.bug.st/serial => github.com/cmaglie/go-serial v0.0.0-20200923162623-b214c147e37e
-
 require (
 	github.com/arduino/arduino-cli v0.0.0-20210603144340-aef5a54882fa
 	github.com/arduino/go-paths-helper v1.6.0
@@ -17,5 +14,5 @@ require (
 	github.com/stretchr/testify v1.6.1
 	go.bug.st/downloader/v2 v2.1.1
 	go.bug.st/relaxed-semver v0.0.0-20190922224835-391e10178d18
-	go.bug.st/serial v1.1.2
+	go.bug.st/serial v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -29,7 +29,6 @@ github.com/arduino/go-paths-helper v1.2.0/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3
 github.com/arduino/go-paths-helper v1.5.0/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
 github.com/arduino/go-paths-helper v1.6.0 h1:S7/d7DqB9XlnvF9KrgSiGmo2oWKmYW6O/DTjj3Bijx4=
 github.com/arduino/go-paths-helper v1.6.0/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
-github.com/arduino/go-properties-orderedmap v1.1.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
 github.com/arduino/go-properties-orderedmap v1.3.0 h1:4No/vQopB36e7WUIk6H6TxiSEJPiMrVOCZylYmua39o=
 github.com/arduino/go-properties-orderedmap v1.3.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b/go.mod h1:uwGy5PpN4lqW97FiLnbcx+xx8jly5YuPMJWfVwwjJiQ=
@@ -47,8 +46,6 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cmaglie/go-serial v0.0.0-20200923162623-b214c147e37e h1:XETkjcWmNrh5M9hIpkgI0uANZsdD8zg2wjDzspe3bRw=
-github.com/cmaglie/go-serial v0.0.0-20200923162623-b214c147e37e/go.mod h1:k7j3AWnS4CLHK94Z32+qkukjlSyASt1YYrbWcnr9r4E=
 github.com/cmaglie/go.rice v1.0.3 h1:ZBLmBdQp6ejc+n8eMNH0uuRSKkg6kKe6ORjXKnyHBYw=
 github.com/cmaglie/go.rice v1.0.3/go.mod h1:AF3bOWkvdOpp8/S3UL8qbQ4N7DiISIbJtj54GWFPAsc=
 github.com/cmaglie/pb v1.0.27/go.mod h1:GilkKZMXYjBA4NxItWFfO+lwkp59PLHQ+IOW/b/kmZI=
@@ -64,8 +61,9 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/creack/goselect v0.1.1 h1:tiSSgKE1eJtxs1h/VgGQWuXUP0YS4CDIFMp6vaI1ls0=
 github.com/creack/goselect v0.1.1/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
+github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
+github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/daaku/go.zipexe v1.0.0 h1:VSOgZtH418pH9L16hC/JrgSNJbbAL26pj7lmD1+CGdY=
@@ -316,6 +314,9 @@ go.bug.st/downloader/v2 v2.1.1 h1:nyqbUizo3E2IxCCm4YFac4FtSqqFpqWP+Aae5GCMuw4=
 go.bug.st/downloader/v2 v2.1.1/go.mod h1:VZW2V1iGKV8rJL2ZEGIDzzBeKowYv34AedJz13RzVII=
 go.bug.st/relaxed-semver v0.0.0-20190922224835-391e10178d18 h1:F1qxtaFuewctYc/SsHRn+Q7Dtwi+yJGPgVq8YLtQz98=
 go.bug.st/relaxed-semver v0.0.0-20190922224835-391e10178d18/go.mod h1:Cx1VqMtEhE9pIkEyUj3LVVVPkv89dgW8aCKrRPDR/uE=
+go.bug.st/serial v1.1.2/go.mod h1:VmYBeyJWp5BnJ0tw2NUJHZdJTGl2ecBGABHlzRK1knY=
+go.bug.st/serial v1.2.0 h1:FsULZW0CMzBp4sb8Cec2AfrAVSF4UorFy7XO3gxLx60=
+go.bug.st/serial v1.2.0/go.mod h1:8TT7u/SwwNIpJ8QaG4s+HTjFt9ReXs2cdOU7ZEk50Dk=
 go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45/go.mod h1:dRSl/CVCTf56CkXgJMDOdSwNfo2g1orOGE/gBGdvjZw=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -346,7 +347,6 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=


### PR DESCRIPTION
This PR fixes an old bug (present before the refactoring). It was not possible to update the NINA firmware on the UNO WiFi rev2. The problem was caused by the rather strange baudrate of the [FirmwareUpdate.ino](https://github.com/arduino-libraries/WiFiNINA/blob/master/examples/Tools/FirmwareUpdater/FirmwareUpdater.ino#L43) sketch. We were using [different baud rates in the `arduino-fwupdater`](https://github.com/arduino/arduino-fwuploader/blob/d3bcb8cc9c428c05428f74b03b911b3c6d8f7e74/flasher/flasher.go#L66-L71). They are not necessary anymore since the uploader sketch it's the same. Furthermore the problem was present only on the UNO WiFi rev2 because it uses a true serial and not a USB one like in the SAMD21 boards
fixes #59 