### PR TITLE
[skip-changelog] fix link validation workflow

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,5 +56,4 @@ The full list of command line options can be obtained with the `-h` option: `./a
 
 For further information you can use the [command reference]
 
-[install]: installation.md
-[command reference]: commands/arduino-fwuploader.md
+[command reference]: https://arduino.github.io/arduino-fwuploader/dev/commands/arduino-fwuploader/


### PR DESCRIPTION
`commands/arduino-fwuploader.md` do not exist when running link-validation workflow. Using full URL instead should fix the problem