### PR TITLE
harden the flashing process on win pt2

### DIFF
--- a/cli/firmware/flash.go
+++ b/cli/firmware/flash.go
@@ -170,22 +170,22 @@ func run(cmd *cobra.Command, args []string) {
 func updateFirmware(board *firmwareindex.IndexBoard, loaderSketch, moduleName string, uploadToolDir, firmwareFile *paths.Path) error {
 	var err error
 	// Check if board needs a 1200bps touch for upload
-	uploadPort := address
+	bootloaderPort := address
 	if board.UploadTouch {
 		logrus.Info("Putting board into bootloader mode")
-		newUploadPort, err := serialutils.Reset(uploadPort, board.UploadWait, nil)
+		newUploadPort, err := serialutils.Reset(address, board.UploadWait, nil)
 		if err != nil {
 			return fmt.Errorf("error during firmware flashing: missing board address. %s", err)
 		}
 		if newUploadPort != "" {
 			logrus.Infof("Found port to upload Loader: %s", newUploadPort)
-			uploadPort = newUploadPort
+			bootloaderPort = newUploadPort
 		}
 	}
 
 	uploaderCommand := board.GetUploaderCommand()
 	uploaderCommand = strings.ReplaceAll(uploaderCommand, "{tool_dir}", filepath.FromSlash(uploadToolDir.String()))
-	uploaderCommand = strings.ReplaceAll(uploaderCommand, "{serial.port.file}", uploadPort)
+	uploaderCommand = strings.ReplaceAll(uploaderCommand, "{serial.port.file}", bootloaderPort)
 	uploaderCommand = strings.ReplaceAll(uploaderCommand, "{loader.sketch}", loaderSketch)
 
 	commandLine, err := properties.SplitQuotedString(uploaderCommand, "\"", false)
@@ -208,15 +208,16 @@ func updateFirmware(board *firmwareindex.IndexBoard, loaderSketch, moduleName st
 
 	// Wait a bit after flashing the loader sketch for the board to become
 	// available again.
-	time.Sleep(2 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	// Get flasher depending on which module to use
 	var f flasher.Flasher
 	switch moduleName {
 	case "NINA":
-		f, err = flasher.NewNinaFlasher(uploadPort)
+		// we use address and not bootloaderPort because the board should not be in bootloader mode
+		f, err = flasher.NewNinaFlasher(address)
 	case "WINC1500":
-		f, err = flasher.NewWincFlasher(uploadPort)
+		f, err = flasher.NewWincFlasher(address)
 	default:
 		err = fmt.Errorf("unknown module: %s", moduleName)
 		feedback.Errorf("Error during firmware flashing: %s", err)


### PR DESCRIPTION
Expands and completes #58
On windows when the board is touched at 1200bps it goes in bootloader mode (on a different COM port).
I used the correct approach in #58, but I forgot that the `commandLine` variable was being set before.. 🤦 

The working principle is the following:
1. The board (a samd once) is present on COM6 for example
2. The board is touched at 1200bps
3. The board comes bach online on a different COM (for example COM7)
4. The uploader sketch must be uploaded keeping in mind this behaviur
5. After the upload is complete **the board returns to the previous COM port** (in our example COM6) <- we were not considering this
6. We open a serial connection to COM6 at 1000000bps to upload the firmware binary to the board.
7. The end 🪂 