### PR TITLE
Generate documentation before running link check

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,6 +24,11 @@ tasks:
     cmds:
       - poetry run mike deploy --update-aliases --push --remote {{.DOCS_REMOTE}} {{.DOCS_VERSION}} {{.DOCS_ALIAS}}
 
+  docs:generate:
+    desc: Create all generated documentation content
+    deps:
+      - task: docs:gen:commands
+
   docs:gen:commands:
     desc: Generate command reference files
     dir: ./docsgen
@@ -43,6 +48,8 @@ tasks:
 
   docs:check-links:
     desc: Verifies there are no dead links in documentation
+    deps:
+      - task: docs:generate
     cmds:
       - |
         npx -p markdown-link-check -c '

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,4 +57,4 @@ The full list of command line options can be obtained with the `-h` option: `./a
 For further information you can use the [command reference]
 
 [install]: installation.md
-[command reference]: https://arduino.github.io/arduino-fwuploader/dev/commands/arduino-fwuploader/
+[command reference]: commands/arduino-fwuploader.md


### PR DESCRIPTION
Some links may point to the generated documentation content, which would result in a failure of the link check.

It's true that these links are indeed broken when accessed outside the website, but the primary publishing location for
this content is the website. The alternative would be checking the generated content into the repository, but this would
either require some fairly complex automation or else a burden on the contributors to keep it synced.