### PR TITLE
[skip-changelog] fix wrong workflow trigger

### DIFF
--- a/.github/workflows/generate-index.yml
+++ b/.github/workflows/generate-index.yml
@@ -4,7 +4,7 @@ name: Generate Index
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "generator/**"
       - "firmwares/**"


### PR DESCRIPTION
The workflow trigger was set to the wrong base branch