### PR TITLE
Sync certificate check workflows with "template"

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -1,33 +1,39 @@
-name: Check for issues with signing certificates
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-certificates.md
+name: Check Signing Certificates
 
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
+  push:
+    paths:
+      - ".github/workflows/check-certificates.ya?ml"
+      - "certs/**"
+  pull_request:
+    paths:
+      - ".github/workflows/check-certificates.ya?ml"
+      - "certs/**"
   schedule:
-    # run every 10 hours
+    # Run every 10 hours.
     - cron: "0 */10 * * *"
-  # workflow_dispatch event allows the workflow to be triggered manually.
-  # This could be used to run an immediate check after updating certificate secrets.
-  # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch
   workflow_dispatch:
+  repository_dispatch:
 
 env:
-  # Begin notifications when there are less than this many days remaining before expiration
+  # Begin notifications when there are less than this many days remaining before expiration.
   EXPIRATION_WARNING_PERIOD: 30
 
 jobs:
   get-certificates-list:
-    # This workflow would fail in forks that don't have the certificate secrets defined
-    if: github.repository == 'arduino/arduino-fwuploader'
     runs-on: ubuntu-latest
     outputs:
       certificates: ${{ steps.get-files.outputs.certificates }}
 
     steps:
-      - name: checkout
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Set certificates path environment variable
         run: |
-          # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "FILES=\"$(ls ${{ github.workspace }}/certs/* | xargs | sed 's/ /","/g')\"" >> $GITHUB_ENV
 
       - name: Get files list
@@ -37,17 +43,15 @@ jobs:
           echo "::set-output name=certificates::$JSON"
 
   check-certificates:
-    # This workflow would fail in forks that don't have the certificate secrets defined
-    if: github.repository == 'arduino/arduino-fwuploader'
-    runs-on: ubuntu-latest
+    name: ${{ matrix.cert_file }}
     needs: get-certificates-list
-
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix: ${{fromJSON(needs.get-certificates-list.outputs.certificates)}}
 
     steps:
-      - name: checkout
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Get days remaining before certificate expiration date
@@ -70,7 +74,7 @@ jobs:
 
           DAYS_BEFORE_EXPIRATION="$((($(date --utc --date="$EXPIRATION_DATE" +%s) - $(date --utc +%s)) / 60 / 60 / 24))"
 
-          # Display the expiration information in the log
+          # Display the expiration information in the log.
           echo "Certificate expiration date: $EXPIRATION_DATE"
           echo "Days remaining before expiration: $DAYS_BEFORE_EXPIRATION"
 
@@ -86,14 +90,16 @@ jobs:
           fi
 
       - name: Slack notification of pending certificate expiration
-        # Don't send spurious expiration notification if verification fails
-        if: failure() && steps.check-expiration.outcome == 'failure'
-        uses: rtCamp/action-slack-notify@v2.1.0
+        # Only run when the workflow will have access to the certificate secrets.
+        if: >
+          failure() &&
+          github.event_name == 'schedule'
         env:
-          SLACK_WEBHOOK: ${{ secrets.TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_MESSAGE: |
             :warning::warning::warning::warning:
             WARNING: ${{ github.repository }} ${{ matrix.cert_file }} will expire in ${{ steps.get-days-before-expiration.outputs.days }} days!!!
             :warning::warning::warning::warning:
           SLACK_COLOR: danger
           MSG_MINIMAL: true
+        uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/check-notarization-certificates.yml
+++ b/.github/workflows/check-notarization-certificates.yml
@@ -1,37 +1,46 @@
-name: Check for issues with notarization certificates
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-certificates.md
+name: Check Notarization Certificates
 
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
+  push:
+    paths:
+      - ".github/workflows/check-notarization-certificates.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-notarization-certificates.ya?ml"
   schedule:
-    # run every 10 hours
+    # Run every 10 hours.
     - cron: "0 */10 * * *"
-  # workflow_dispatch event allows the workflow to be triggered manually.
-  # This could be used to run an immediate check after updating certificate secrets.
-  # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch
   workflow_dispatch:
+  repository_dispatch:
 
 env:
-  # Begin notifications when there are less than this many days remaining before expiration
+  # Begin notifications when there are less than this many days remaining before expiration.
   EXPIRATION_WARNING_PERIOD: 30
 
 jobs:
   check-certificates:
-    # This workflow would fail in forks that don't have the certificate secrets defined
-    if: github.repository == 'arduino/arduino-fwuploader'
+    name: ${{ matrix.certificate.identifier }}
+    # Only run when the workflow will have access to the certificate secrets.
+    if: >
+      (github.event_name != 'pull_request' && github.repository == 'arduino/arduino-fwuploader') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'arduino/arduino-fwuploader')
     runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
 
       matrix:
         certificate:
-          - identifier: macOS signing certificate # Text used to identify the certificate in notifications
-            certificate-secret: INSTALLER_CERT_MAC_P12 # The name of the secret that contains the certificate
-            password-secret: INSTALLER_CERT_MAC_PASSWORD # The name of the secret that contains the certificate password
+          # Additional certificate definitions can be added to this list.
+          - identifier: macOS signing certificate # Text used to identify certificate in notifications.
+            certificate-secret: INSTALLER_CERT_MAC_P12 # Name of the secret that contains the certificate.
+            password-secret: INSTALLER_CERT_MAC_PASSWORD # Name of the secret that contains the certificate password.
 
     steps:
       - name: Set certificate path environment variable
         run: |
-          # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          # See: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "CERTIFICATE_PATH=${{ runner.temp }}/certificate.p12" >> "$GITHUB_ENV"
 
       - name: Decode certificate
@@ -53,18 +62,17 @@ jobs:
             exit 1
           )
 
-      # See: https://github.com/rtCamp/action-slack-notify
       - name: Slack notification of certificate verification failure
         if: failure()
-        uses: rtCamp/action-slack-notify@v2.1.0
         env:
-          SLACK_WEBHOOK: ${{ secrets.TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_MESSAGE: |
             :warning::warning::warning::warning:
             WARNING: ${{ github.repository }} ${{ matrix.certificate.identifier }} verification failed!!!
             :warning::warning::warning::warning:
           SLACK_COLOR: danger
           MSG_MINIMAL: true
+        uses: rtCamp/action-slack-notify@v2
 
       - name: Get days remaining before certificate expiration date
         env:
@@ -93,7 +101,7 @@ jobs:
 
           DAYS_BEFORE_EXPIRATION="$((($(date --utc --date="$EXPIRATION_DATE" +%s) - $(date --utc +%s)) / 60 / 60 / 24))"
 
-          # Display the expiration information in the log
+          # Display the expiration information in the log.
           echo "Certificate expiration date: $EXPIRATION_DATE"
           echo "Days remaining before expiration: $DAYS_BEFORE_EXPIRATION"
 
@@ -108,14 +116,14 @@ jobs:
           fi
 
       - name: Slack notification of pending certificate expiration
-        # Don't send spurious expiration notification if verification fails
+        # Don't send spurious expiration notification if verification fails.
         if: failure() && steps.check-expiration.outcome == 'failure'
-        uses: rtCamp/action-slack-notify@v2.1.0
         env:
-          SLACK_WEBHOOK: ${{ secrets.TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_MESSAGE: |
             :warning::warning::warning::warning:
             WARNING: ${{ github.repository }} ${{ matrix.certificate.identifier }} will expire in ${{ steps.get-days-before-expiration.outputs.days }} days!!!
             :warning::warning::warning::warning:
           SLACK_COLOR: danger
           MSG_MINIMAL: true
+        uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
We have assembled a collection of reusable GitHub Actions workflows:
https://github.com/arduino/tooling-project-assets
These workflows will be used in the repositories of all Arduino tooling projects.

Some minor improvements and standardizations have been made in the upstream "template" workflow, and those are introduced
to this repository here.

Notable:

- Run workflows on their modification when possible to facilitate development and review
- Run "Check Certificates" workflow on certificate file modification
- Allow triggering workflows via GitHub API
- Improved readability of matrix job names
- Use Slack webhook secret name more appropriate for general application of the "template" workflow
- Use major version ref of `rtCamp/action-slack-notify` action for automatic updates to all its non-breaking releases

---
NOTE: I have already added the required `SLACK_WEBHOOK` secret and will remove the unused `TEAM_TOOLING_CHANNEL_SLACK_WEBHOOK` secret from the repository once merged.

Demos with simulated failures:

- https://github.com/per1234/arduino-fwuploader/runs/3326603543 (I added garbage data in place of the notarization certificate secrets in my fork)
- https://github.com/per1234/arduino-fwuploader/actions/runs/1129335832 (I changed `EXPIRATION_WARNING_PERIOD` to 3000)