### PR TITLE
Make taskfile compatible with Go 1.16

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,6 +59,21 @@ tasks:
     cmds:
       - poetry run mkdocs build -s
 
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
+  go:lint:
+    desc: Lint Go code
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
+    cmds:
+      - |
+        if ! which golint &>/dev/null; then
+          echo "golint not installed or not in PATH. Please install: https://github.com/golang/lint#installation"
+          exit 1
+        fi
+      - |
+        golint \
+          {{default "-min_confidence 0.8 -set_exit_status" .GO_LINT_FLAGS}} \
+          {{default .DEFAULT_GO_PACKAGES .GO_PACKAGES}}
+
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-markdown-task/Taskfile.yml
   markdown:check-links:
     desc: Check for broken links
@@ -142,7 +157,7 @@ tasks:
     cmds:
       - test -z $(go fmt ./...)
       - go vet ./...
-      - "'{{.GOLINTBIN}}' {{.GOLINTFLAGS}} ./..."
+      - task: go:lint
       - task: docs:check
       - task: config:check
       - task: general:check-formatting
@@ -190,6 +205,11 @@ tasks:
 vars:
   PROJECT_NAME: "arduino-fwuploader"
   DIST_DIR: "dist"
+  # Path of the project's primary Go module:
+  DEFAULT_GO_MODULE_PATH: ./
+  DEFAULT_GO_PACKAGES:
+    sh: |
+      echo $(cd {{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}} && go list ./... | tr '\n' ' ' || echo '"ERROR: Unable to discover Go packages"')
   # build vars
   COMMIT:
     sh: echo "$(git log -n 1 --format=%h)"
@@ -219,9 +239,6 @@ vars:
     -X github.com/arduino/arduino-fwuploader/version.date={{.TIMESTAMP}}
     '
   # check-lint vars
-  GOLINTBIN:
-    sh: go list -f {{"{{"}}".Target{{"}}"}}" golang.org/x/lint/golint
-  GOLINTFLAGS: "-min_confidence 0.8 -set_exit_status"
   PRETTIER: prettier@2.0.5
   DOCS_VERSION: dev
   DOCS_ALIAS: ""

--- a/go.sum
+++ b/go.sum
@@ -347,7 +347,6 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=


### PR DESCRIPTION
The `go list` command used to set the dynamic taskfile variable to the path of the golint installation does not work in
the "module-aware mode" that is now Go's default (and only in 1.17). Causing every task to fail after the module has been
tidied:

```
$ go mod tidy && task build
missing go.sum entry for module providing package golang.org/x/lint/golint; to add:
        go mod download golang.org/x/lint
task: Command "go list -f {{".Target}}" golang.org/x/lint/golint" failed: exit status 1
```

In the end, I gave up on making it work as before. I think it's better to require the user to install golint and put the
installation in the system `PATH`, making the linting task display a helpful message when this has not been done.