### PR TITLE
Sync release assets with templates

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -1,4 +1,16 @@
-name: release
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/release-go-task.md
+name: Release
+
+env:
+  # As defined by the Taskfile's PROJECT_NAME variable
+  PROJECT_NAME: arduino-fwuploader
+  # As defined by the Taskfile's DIST_DIR variable
+  DIST_DIR: dist
+  # The project's folder on Arduino's download server for uploading builds
+  AWS_PLUGIN_TARGET: /arduino-fwuploader/
+  ARTIFACT_NAME: dist
+  # See: https://github.com/actions/setup-go/tree/v2#readme
+  GO_VERSION: ^1.16.2
 
 on:
   push:
@@ -10,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -18,20 +30,21 @@ jobs:
       - name: Create changelog
         uses: arduino/create-changelog@v1
         with:
-          tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+$'
+          tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
           filter-regex: '^\[(skip|changelog)[ ,-](skip|changelog)\].*'
           case-insensitive-regex: true
-          changelog-file-path: "dist/CHANGELOG.md"
+          changelog-file-path: "${{ env.DIST_DIR }}/CHANGELOG.md"
 
-      - name: Install Taskfile
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Task
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
-
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "^1.16.2"
 
       - name: Build
         run: task dist:all
@@ -39,24 +52,23 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: dist
-          path: dist
+          if-no-files-found: error
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
   notarize-macos:
     runs-on: macos-latest
     needs: create-release-artifacts
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          # to ensure compatibility with v1
-          # https://github.com/actions/download-artifact#compatibility-between-v1-and-v2
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
       - name: Import Code-Signing Certificates
         env:
@@ -64,12 +76,22 @@ jobs:
           INSTALLER_CERT_MAC_PATH: "/tmp/ArduinoCerts2020.p12"
           KEYCHAIN_PASSWORD: keychainpassword # Arbitrary password for a keychain that exists only for the duration of the job, so not secret
         run: |
-          echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > ${{ env.INSTALLER_CERT_MAC_PATH }}
-          security create-keychain -p ${{ env.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
-          security default-keychain -s ${{ env.KEYCHAIN }}
-          security unlock-keychain -p ${{ env.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
-          security import ${{ env.INSTALLER_CERT_MAC_PATH }} -k ${{ env.KEYCHAIN }} -f pkcs12 -A -T /usr/bin/codesign -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
-          security set-key-partition-list -S apple-tool:,apple: -s -k ${{ env.KEYCHAIN_PASSWORD }} ${{ env.KEYCHAIN }}
+          echo "${{ secrets.INSTALLER_CERT_MAC_P12 }}" | base64 --decode > "${{ env.INSTALLER_CERT_MAC_PATH }}"
+          security create-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security default-keychain -s "${{ env.KEYCHAIN }}"
+          security unlock-keychain -p "${{ env.KEYCHAIN_PASSWORD }}" "${{ env.KEYCHAIN }}"
+          security import \
+            "${{ env.INSTALLER_CERT_MAC_PATH }}" \
+            -k "${{ env.KEYCHAIN }}" \
+            -f pkcs12 \
+            -A \
+            -T "/usr/bin/codesign" \
+            -P "${{ secrets.INSTALLER_CERT_MAC_PASSWORD }}"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "${{ env.KEYCHAIN_PASSWORD }}" \
+            "${{ env.KEYCHAIN }}"
 
       - name: Install gon for code signing and app notarization
         run: |
@@ -83,22 +105,24 @@ jobs:
         run: |
           gon gon.config.hcl
 
-      - name: Re-package binary and update checksum
-        # Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
+      - name: Re-package binary
+        # This step performs the following:
+        # 1. Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         run: |
           # GitHub's upload/download-artifact@v2 actions don't preserve file permissions,
-          # so we need to add execution permission back.
-          chmod +x dist/macos64/arduino-fwuploader
-          TAG=${GITHUB_REF/refs\/tags\//}
-          tar czf dist/arduino-fwuploader_${TAG}_macOS_64bit.tar.gz \
-          LICENSE.txt \
-          -C dist/macos64/ arduino-fwuploader
+          # so we need to add execution permission back until the action is made to do this.
+          chmod +x ${{ env.DIST_DIR }}/macos64/${{ env.PROJECT_NAME }}
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          tar -czvf "${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_${TAG}_macOS_64bit.tar.gz" \
+            LICENSE.txt \
+            -C ${{ env.DIST_DIR }}/macos64/ ${{ env.PROJECT_NAME }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: dist
-          path: dist
+          if-no-files-found: error
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
   create-release:
     runs-on: ubuntu-latest
@@ -111,10 +135,8 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          # to ensure compatibility with v1
-          # https://github.com/actions/download-artifact#compatibility-between-v1-and-v2
-          path: dist
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
 
       - name: Install Taskfile
         uses: arduino/setup-task@v1
@@ -134,23 +156,23 @@ jobs:
         run: |
           wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.0.0.zip
           unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
-          if [[ $(/tmp/semver get prerel ${GITHUB_REF/refs\/tags\//}) ]]; then echo "::set-output name=IS_PRE::true"; fi
+          if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
 
       - name: Create Github Release and upload artifacts
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          bodyFile: "dist/CHANGELOG.md"
+          bodyFile: ${{ env.DIST_DIR }}/CHANGELOG.md
           draft: false
           prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
-          artifacts: dist/arduino-fwuploader*,dist/package_index.json
+          artifacts: ${{ env.DIST_DIR }}/arduino-fwuploader*,${{ env.DIST_DIR }}/package_index.json
 
       - name: Upload release files on Arduino downloads servers
         uses: docker://plugins/s3
         env:
-          PLUGIN_SOURCE: "dist/arduino-fwuploader*"
-          PLUGIN_TARGET: "/arduino-fwuploader/"
-          PLUGIN_STRIP_PREFIX: "dist/"
+          PLUGIN_SOURCE: "${{ env.DIST_DIR }}/arduino-fwuploader*"
+          PLUGIN_TARGET: ${{ env.AWS_PLUGIN_TARGET }}
+          PLUGIN_STRIP_PREFIX: "${{ env.DIST_DIR }}/"
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -218,20 +218,21 @@ vars:
       echo $(cd {{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}} && go list ./... | tr '\n' ' ' || echo '"ERROR: Unable to discover Go packages"')
   # build vars
   COMMIT:
-    sh: echo "$(git log -n 1 --format=%h)"
+    sh: echo "$(git log --no-show-signature -n 1 --format=%h)"
   TIMESTAMP:
     sh: echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   TIMESTAMP_SHORT:
     sh: echo "{{now | date "20060102"}}"
   TAG:
-    sh: echo "`git tag --points-at=HEAD 2> /dev/null | head -n1`"
-  VERSION: "{{ if .NIGHTLY }}nightly-{{ .TIMESTAMP_SHORT }}{{ else if .TAG }}{{ .TAG }}{{ else }}{{ .PACKAGE_NAME_PREFIX }}git-snapshot{{ end }}"
+    sh: echo "$(git tag --points-at=HEAD 2> /dev/null | head -n1)"
+  VERSION: "{{if .NIGHTLY}}nightly-{{.TIMESTAMP_SHORT}}{{else if .TAG}}{{.TAG}}{{else}}{{.PACKAGE_NAME_PREFIX}}git-snapshot{{end}}"
+  CONFIGURATION_PACKAGE: github.com/arduino/arduino-fwuploader/version
   LDFLAGS: >
     -ldflags
     '
-    -X github.com/arduino/arduino-fwuploader/version.versionString={{.VERSION}}
-    -X github.com/arduino/arduino-fwuploader/version.commit={{ .COMMIT }}
-    -X github.com/arduino/arduino-fwuploader/version.date={{.TIMESTAMP}}
+    -X {{.CONFIGURATION_PACKAGE}}.versionString={{.VERSION}}
+    -X {{.CONFIGURATION_PACKAGE}}.commit={{ .COMMIT }}
+    -X {{.CONFIGURATION_PACKAGE}}.date={{.TIMESTAMP}}
     '
   # test vars
   GOFLAGS: "-timeout 10m -v -coverpkg=./... -covermode=atomic"
@@ -240,9 +241,9 @@ vars:
   TEST_LDFLAGS: >
     -ldflags
     '
-    -X github.com/arduino/arduino-fwuploader/version.versionString={{.TEST_VERSION}}
-    -X github.com/arduino/arduino-fwuploader/version.commit={{.TEST_COMMIT}}
-    -X github.com/arduino/arduino-fwuploader/version.date={{.TIMESTAMP}}
+    -X {{.CONFIGURATION_PACKAGE}}.versionString={{.TEST_VERSION}}
+    -X {{.CONFIGURATION_PACKAGE}}.commit={{.TEST_COMMIT}}
+    -X {{.CONFIGURATION_PACKAGE}}.date={{.TIMESTAMP}}
     '
   # check-lint vars
   PRETTIER: prettier@2.0.5

--- a/gon.config.hcl
+++ b/gon.config.hcl
@@ -1,3 +1,5 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/general/gon.config.hcl
+# See: https://github.com/mitchellh/gon#configuration-file
 source = ["dist/macos64/arduino-fwuploader"]
 bundle_id = "cc.arduino.arduino-fwuploader"
 
@@ -8,5 +10,5 @@ sign {
 # Ask Gon for zip output to force notarization process to take place.
 # The CI will ignore the zip output, using the signed binary only.
 zip {
-  output_path = "arduino-fwuploader.zip"
+  output_path = "unused.zip"
 }


### PR DESCRIPTION
We have assembled a collection of reusable project assets:
https://github.com/arduino/tooling-project-assets
These assets will be used in the repositories of all Arduino tooling projects.

Some improvements and standardizations have been made in the upstream "template" release assets, and those are introduced
to this repository here.

Notable:

- Handle signed commits (https://github.com/arduino/arduino-cli/pull/1344)
- Make changelog generation system work correctly for pre-releases (https://github.com/arduino/arduino-cli/pull/1284)
- Improve failure detection

---
Demo release from my fork:
https://github.com/per1234/arduino-fwuploader/actions/runs/1131445405
https://github.com/per1234/arduino-fwuploader/releases/tag/2.2.2