### PR TITLE
bump mbed core to latest

### DIFF
--- a/.github/workflows/generate-index.yml
+++ b/.github/workflows/generate-index.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           SAMD_V: 1.8.11
           MEGAAVR_V: 1.8.7
-          MBED_NANO_V: 2.3.1
+          MBED_NANO_V: 2.4.1
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The **Board** field when running `arduino-fwuploader firmware list`

```
$ arduino-fwuploader firmware list -b arduino:mbed_nano:nanorp2040connect
Board FQBN                                Module   Version
      arduino:mbed_nano:nanorp2040connect NINA     1.4.5  
      arduino:mbed_nano:nanorp2040connect NINA     1.4.6  
      arduino:mbed_nano:nanorp2040connect NINA     1.4.7  
      arduino:mbed_nano:nanorp2040connect NINA   ✔ 1.4.8
```
I have opened an issue on the `arduino-cli` repo because apparently the problem comes from it:
https://github.com/arduino/arduino-cli/issues/1401

The cli is used to obtain the name of the board, by the generator, which is run by the CI in the `generate-index.json` workflow. This is only a temporary fix, while we wait for the fix in `arduino-cli`


This is the diff before and after this commit:
```patch
--- /home/umberto/Nextcloud/8tb/Lavoro/arduino-fwuploader/generator/boards/module_firmware_index.json
+++ /home/umberto/Nextcloud/8tb/Lavoro/arduino-fwuploader/generator/boards/module_firmware_index.json.new
@@ -493,6 +493,7 @@
       "size": "1674900"
     },
     "module": "NINA",
+    "name": "Arduino Nano RP2040 Connect",
     "uploader": "arduino:rp2040tools@1.0.2",
     "upload.use_1200bps_touch": true,
     "upload.wait_for_upload_port": true,

```