### PR TITLE
[skip-changelog] Revert "pin task version in workflows running on windows"

### DIFF
--- a/.github/workflows/check-go-cross-build-task.yml
+++ b/.github/workflows/check-go-cross-build-task.yml
@@ -74,7 +74,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.9.0
+          version: 3.x
 
       - name: Build native
         run: task build

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -95,7 +95,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.9.0
+          version: 3.x
 
       - name: Run integration tests
         run: task go:test-integration

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -89,7 +89,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.9.0
+          version: 3.x
 
       - name: Run tests
         env:


### PR DESCRIPTION
This reverts commit f9aa597679b6ee3207d156a676388750368d262d.

Related to https://github.com/arduino/tooling-project-assets/pull/186