### PR TITLE
[skip-changelog] Correct Google TLD in `certificates flash` example commands

### DIFF
--- a/cli/certificates/flash.go
+++ b/cli/certificates/flash.go
@@ -50,7 +50,7 @@ func NewFlashCommand() *cobra.Command {
 		Long:  "Flashes specified certificates to board at specified address.",
 		Example: "" +
 			"  " + os.Args[0] + " certificates flash --fqbn arduino:samd:mkr1000 --address COM10 --url arduino.cc:443 --file /home/me/Digicert.cer\n" +
-			"  " + os.Args[0] + " certificates flash -b arduino:samd:mkr1000 -a COM10 -u arduino.cc:443 -u google.cc:443\n" +
+			"  " + os.Args[0] + " certificates flash -b arduino:samd:mkr1000 -a COM10 -u arduino.cc:443 -u google.com:443\n" +
 			"  " + os.Args[0] + " certificates flash -b arduino:samd:mkr1000 -a COM10 -f /home/me/VeriSign.cer -f /home/me/Digicert.cer\n",
 		Args: cobra.NoArgs,
 		Run:  runFlash,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,7 +71,7 @@ You can also use the `--format json` flag to parse the output with more ease.
 The tool offers also the ability to flash SSL certificates to a module:
 
 ```
-./arduino-fwuploader certificates flash -b arduino:samd:nano_33_iot" -a COM10 -u arduino.cc:443 -u google.cc:443
+./arduino-fwuploader certificates flash -b arduino:samd:nano_33_iot" -a COM10 -u arduino.cc:443 -u google.com:443
 ```
 
 or you can specify a path to a file with `-f` instead of the URL of the certificate


### PR DESCRIPTION
Previously, the `arduino-fwuploader certificates flash` example commands in [the command line help](https://arduino.github.io/arduino-fwuploader/dev/commands/arduino-fwuploader_certificates_flash/) and ["Usage" documentation](https://arduino.github.io/arduino-fwuploader/dev/usage/#certificates) used the domain `google.cc` for the download of the Google SSL certificate. Although it does work (`google.cc` redirects to `google.com`), I suspect the use of the `.cc` TLD was accidental, originating from the correct use of that TLD for the Arduino certificate domain (i.e., `arduino.cc:443`).

The example commands are hereby updated to use `google.com`.