### PR TITLE
remove old unused tasks, .PRETTIER was not even defined

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,16 +19,6 @@ tasks:
       # Make the formatting consistent with the non-generated Markdown
       - task: general:format-prettier
 
-  docs:check:
-    desc: Run documentation linting
-    cmds:
-      - npx {{ .PRETTIER }} --check "**/*.md"
-
-  docs:format:
-    desc: Automatically formats documentation
-    cmds:
-      - npx {{ .PRETTIER }} --write "**/*.md"
-
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-dependencies-task/Taskfile.yml
   general:cache-dep-licenses:
     desc: Cache dependency license metadata

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -178,7 +178,6 @@ tasks:
       - test -z $(go fmt ./...)
       - go vet ./...
       - task: go:lint
-      - task: docs:check
       - task: config:check
       - task: general:check-formatting
       - task: markdown:check-links


### PR DESCRIPTION
Probably some leftover from some copy/paste. The removed tasks were not working and should be superseded by  `markdown:` ones