### PR TITLE
add support for `.pem` cert format

### DIFF
--- a/.licenses/go/golang.org/x/sys/internal/unsafeheader.dep.yml
+++ b/.licenses/go/golang.org/x/sys/internal/unsafeheader.dep.yml
@@ -1,13 +1,13 @@
 ---
 name: golang.org/x/sys/internal/unsafeheader
-version: v0.0.0-20200909081042-eff7692f9009
+version: v0.0.0-20220422013727-9388b58f7150
 type: go
 summary: Package unsafeheader contains header declarations for the Go runtime's slice
   and string implementations.
 homepage: https://pkg.go.dev/golang.org/x/sys/internal/unsafeheader
 license: bsd-3-clause
 licenses:
-- sources: sys@v0.0.0-20200909081042-eff7692f9009/LICENSE
+- sources: sys@v0.0.0-20220422013727-9388b58f7150/LICENSE
   text: |
     Copyright (c) 2009 The Go Authors. All rights reserved.
 
@@ -36,7 +36,7 @@ licenses:
     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-- sources: sys@v0.0.0-20200909081042-eff7692f9009/PATENTS
+- sources: sys@v0.0.0-20220422013727-9388b58f7150/PATENTS
   text: |
     Additional IP Rights Grant (Patents)
 

--- a/.licenses/go/golang.org/x/sys/unix.dep.yml
+++ b/.licenses/go/golang.org/x/sys/unix.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: golang.org/x/sys/unix
-version: v0.0.0-20200909081042-eff7692f9009
+version: v0.0.0-20220422013727-9388b58f7150
 type: go
 summary: Package unix contains an interface to the low-level operating system primitives.
 homepage: https://pkg.go.dev/golang.org/x/sys/unix
 license: bsd-3-clause
 licenses:
-- sources: sys@v0.0.0-20200909081042-eff7692f9009/LICENSE
+- sources: sys@v0.0.0-20220422013727-9388b58f7150/LICENSE
   text: |
     Copyright (c) 2009 The Go Authors. All rights reserved.
 
@@ -35,7 +35,7 @@ licenses:
     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-- sources: sys@v0.0.0-20200909081042-eff7692f9009/PATENTS
+- sources: sys@v0.0.0-20220422013727-9388b58f7150/PATENTS
   text: |
     Additional IP Rights Grant (Patents)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,7 +74,8 @@ The tool offers also the ability to flash SSL certificates to a module:
 ./arduino-fwuploader certificates flash -b arduino:samd:nano_33_iot" -a COM10 -u arduino.cc:443 -u google.com:443
 ```
 
-or you can specify a path to a file in `.der` format with `-f` instead of the URL of the certificate
+or you can specify a path to a file in `.der` format or in `.pem` format with `-f` or `--file` instead of the URL of the
+certificate
 
 Due to a limitation on the handling of certs in the NINA modules, when `certificates flash` command is launched, all the
 previous certificates are going to be erased. To overcome this it's required to upload them all together:

--- a/docsgen/go.sum
+++ b/docsgen/go.sum
@@ -397,6 +397,8 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 h1:W0lCpv29Hv0UaM1LXb9QlBHLNP8UFfcKjblhVCWftOM=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/flasher/nina.go
+++ b/flasher/nina.go
@@ -147,14 +147,21 @@ func (f *NinaFlasher) certificateFromFile(certificateFile *paths.Path) ([]byte, 
 		logrus.Error(err)
 		return nil, err
 	}
-
-	cert, err := x509.ParseCertificate(data)
-	if err != nil {
-		logrus.Error(err)
-		return nil, err
+	switch certificateFile.Ext() {
+	case ".cer":
+		// the data needs to be formatted in PEM format
+		cert, err := x509.ParseCertificate(data)
+		if err != nil {
+			logrus.Error(err)
+			return nil, err
+		}
+		return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}), nil
+	case ".pem":
+		// the data is already encoded in pem format and we do not need to parse it.
+		return data, nil
+	default:
+		return nil, fmt.Errorf("cert format %s not supported, please use .pem or .cer", certificateFile.Ext())
 	}
-
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}), nil
 }
 
 func (f *NinaFlasher) certificateFromURL(URL string) ([]byte, error) {

--- a/flasher/winc.go
+++ b/flasher/winc.go
@@ -119,14 +119,20 @@ func (f *WincFlasher) certificateFromFile(certificateFile *paths.Path) ([]byte, 
 		logrus.Error(err)
 		return nil, err
 	}
-
-	cert, err := x509.ParseCertificate(data)
-	if err != nil {
-		logrus.Error(err)
-		return nil, err
+	switch certificateFile.Ext() {
+	case ".cer":
+		cert, err := x509.ParseCertificate(data)
+		if err != nil {
+			logrus.Error(err)
+			return nil, err
+		}
+		return f.getCertificateData(cert)
+	case ".pem":
+		// the data is already encoded in pem format and we do not need to parse it.
+		return data, nil
+	default:
+		return nil, fmt.Errorf("cert format %s not supported, please use .pem or .cer", certificateFile.Ext())
 	}
-
-	return f.getCertificateData(cert)
 }
 
 func (f *WincFlasher) certificateFromURL(URL string) ([]byte, error) {

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,5 @@ require (
 	go.bug.st/downloader/v2 v2.1.1
 	go.bug.st/relaxed-semver v0.0.0-20190922224835-391e10178d18
 	go.bug.st/serial v1.3.0
+	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -403,6 +403,8 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 h1:W0lCpv29Hv0UaM1LXb9QlBHLNP8UFfcKjblhVCWftOM=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
Before this change, only `.cer` certificate support was supported. With this also the `.pem` encoded one are supported. The doc has been updated accordingly