### PR TITLE
fix darwin m1 host name

### DIFF
--- a/extras/package_index.json.template
+++ b/extras/package_index.json.template
@@ -38,7 +38,7 @@
               "size": "%%OSX64_SIZE%%"
             },
             {
-              "host": "aarch64-apple-darwin",
+              "host": "arm64-apple-darwin",
               "url": "http://downloads.arduino.cc/arduino-fwuploader/%%FILENAME%%_%%VERSION%%_macOS_ARM64.tar.gz",
               "archiveFileName": "%%FILENAME%%_%%VERSION%%_macOS_ARM64.tar.gz",
               "checksum": "SHA-256:%%OSXARM64_SHA%%",


### PR DESCRIPTION
The correct target listed by `gcc` is `arm64-apple-darwin...` and not `aarch64-apple-darwin...`. See also https://github.com/arduino/arduino-cli/blob/10107d2407c2d9997310fc2e0f22dfd15d48e9a8/arduino/cores/tools.go#L135.