### PR TITLE
Clean up temporary files on exit

### DIFF
--- a/indexes/download/download.go
+++ b/indexes/download/download.go
@@ -229,7 +229,7 @@ func DownloadIndex(indexURL string) (*paths.Path, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer tempDir.Remove()
+	defer tempDir.RemoveAll()
 
 	// Download index
 	tmpGZIndex := tempDir.Join("index.gz")

--- a/indexes/indexes.go
+++ b/indexes/indexes.go
@@ -89,6 +89,7 @@ func GetPackageIndex() (*packageindex.Index, error) {
 
 // GetFirmwareIndex downloads and loads the arduino-fwuploader module_firmware_index.json
 func GetFirmwareIndex() (*firmwareindex.Index, error) {
+	defer globals.FwUploaderPath.RemoveAll()
 	indexPath, err := download.DownloadIndex(globals.ModuleFirmwareIndexGZURL)
 	if err != nil {
 		logrus.Error(err)

--- a/indexes/indexes_test.go
+++ b/indexes/indexes_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/arduino/arduino-cli/arduino/cores/packageindex"
+	"github.com/arduino/arduino-fwuploader/cli/globals"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/require"
 )
@@ -47,4 +48,5 @@ func TestGetFirmwareIndex(t *testing.T) {
 	index, err := GetFirmwareIndex()
 	require.NoError(t, err)
 	require.NotNil(t, index)
+	require.NoDirExists(t, globals.FwUploaderPath.String())
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Code imperfection fix
<!-- Bug fix, feature, docs update, ... -->

## What is the current behavior?
Temporary files and directories created running the command `arduino-fwuploader firmware list` are not cleaned up on exit. There are two reasons behind this behavior. The temporary directory with a name format `55770067919477794103602099745` is not cleaned up because the `DownloadIndex()` function is trying to remove an empty directory (which is not), silently failing while doing so.  On the other hand, the removal of `fwuploader` is never addressed.
<!-- You can also link to an open issue here -->

## What is the new behavior?
Temporary files and directories are correctly cleaned up on exit.  The directory named `fwuploader` is removed by the function `GetFirmwareIndex()` because doing it prematurely in `DownloadIndex()` would cause the command to fail.
<!-- if this is a feature change -->
