### PR TITLE
Use project Go version for generating website content

### DIFF
--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -1,6 +1,10 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-markdown-task.md
 name: Check Markdown
 
+env:
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
+  GO_VERSION: "1.18"
+
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
@@ -55,6 +59,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Task
         uses: arduino/setup-task@v1

--- a/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
+++ b/.github/workflows/deploy-cobra-mkdocs-versioned-poetry.yml
@@ -2,6 +2,8 @@
 name: Deploy Website
 
 env:
+  # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
+  GO_VERSION: "1.18"
   # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
   PYTHON_VERSION: "3.9"
 
@@ -58,6 +60,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
The project documentation is published on [a companion website](https://arduino.github.io/arduino-fwuploader/dev/). A GitHub Actions workflow is used to automatically update the website whenever any relevant file is changed in the repository. This website includes [content generated from the project's Go code](https://arduino.github.io/arduino-fwuploader/dev/commands/arduino-fwuploader/).

Previously, the default version of Go from the GitHub Actions runner machine was used for generating the documentation content. A recent update of this default Go version from 1.17 to 1.20 (https://github.com/actions/runner-images/issues/7276) caused the generation process to fail:

https://github.com/arduino/arduino-fwuploader/actions/runs/4923760846/jobs/8795964719#step:4:39

```text
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x83c1a6]

goroutine 1 [running]:
debug/elf.(*Section).ReadAt(0xc0001be000?, {0xc0001ce000?, 0x24?, 0x23?}, 0x23?)
	<autogenerated>:1 +0x26
archive/zip.readDirectoryEnd({0xa37480, 0xc0000af580}, 0x210)
	/opt/hostedtoolcache/go/1.20.3/x64/src/archive/zip/reader.go:581 +0xf5
archive/zip.(*Reader).init(0xc000137500, {0xa37480?, 0xc0000af580}, 0x210)
	/opt/hostedtoolcache/go/1.20.3/x64/src/archive/zip/reader.go:124 +0x5c
archive/zip.NewReader({0xa37480, 0xc0000af580}, 0x210)
	/opt/hostedtoolcache/go/1.20.3/x64/src/archive/zip/reader.go:103 +0x5e
github.com/daaku/go%2ezipexe.zipExeReaderElf({0xa380[40](https://github.com/arduino/arduino-fwuploader/actions/runs/4923760846/jobs/8795964719#step:4:41)?, 0xc0000140f0}, 0xdc51bf)
	/home/runner/go/pkg/mod/github.com/daaku/go.zipexe@v1.0.0/zipexe.go:128 +0x8b
github.com/daaku/go%2ezipexe.NewReader({0xa38040, 0xc0000140f0}, 0x0?)
	/home/runner/go/pkg/mod/github.com/daaku/go.zipexe@v1.0.0/zipexe.go:48 +0x98
github.com/daaku/go%2ezipexe.OpenCloser({0xc0000822a0?, 0xc0000e5720?})
	/home/runner/go/pkg/mod/github.com/daaku/go.zipexe@v1.0.0/zipexe.go:30 +0x57
github.com/cmaglie/go%2erice.init.0()
	/home/runner/go/pkg/mod/github.com/cmaglie/go.rice@v1.0.3/appended.go:[42](https://github.com/arduino/arduino-fwuploader/actions/runs/4923760846/jobs/8795964719#step:4:43) +0x65
task: Failed to run task "go:cli-docs": exit status 2
```

The "Deploy Website" workflow runs would fail with the same error, but a run hasn't been triggered since the change to the GitHub Actions runner machine (due to lack of activity in the repo). You can see a demonstration of the failure in a workflow run I triggered in my fork:

https://github.com/per1234/arduino-fwuploader/actions/runs/4955614245/jobs/8865167570#step:6:48

This error, and the general fragility that comes from the lack of control over the Go version, is avoided by configuring the workflow to use the specific version of Go that is used for development and validation of the project.

---

Demonstration in my fork of a successful run of the updated "**Deploy Website**" workflow: 

https://github.com/per1234/arduino-fwuploader/actions/runs/4955616902/jobs/8865172681#step:7:49

Demonstration run of the updated "**Check Markdown**" workflow:

https://github.com/arduino/arduino-fwuploader/actions/runs/4955646801/jobs/8865232351?pr=167#step:5:1