### PR TITLE
Fix regression on winc when flashing pem certificates

### DIFF
--- a/flasher/winc.go
+++ b/flasher/winc.go
@@ -83,6 +83,16 @@ func (f *WincFlasher) FlashCertificates(certificatePaths *paths.PathList, URLs [
 		logrus.Infof("Converting and flashing certificate %s", certPath)
 		flasherOut.Write([]byte(fmt.Sprintf("Converting and flashing certificate %s\n", certPath)))
 
+		// Needed to mantain backword compatability
+		if certPath.Ext() == ".pem" {
+			certData, err := certPath.ReadFile()
+			if err != nil {
+				return err
+			}
+			certificatesData = append(certificatesData, certData...)
+			continue
+		}
+
 		certs, err := certificates.LoadCertificatesFromFile(certPath)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixed a regression in the winc flasher when trying to upload .pem files
