### PR TITLE
Add "Plugins" page to the website navigation panel

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,3 +59,4 @@ nav:
       - firmware get-version: commands/arduino-fwuploader_firmware_get-version.md
       - firmware list: commands/arduino-fwuploader_firmware_list.md
       - version: commands/arduino-fwuploader_version.md
+  - Plugins: plugins.md


### PR DESCRIPTION
The project documentation is published in a website generated by [**MkDocs**](https://www.mkdocs.org/).

The primary UI for discovering and accessing the various pages of the site is through the navigation panel/menu. In order to have control over the structure, the contents of the navigation element are explicitly defined in the `nav` key of the MkDocs configuration file:

https://www.mkdocs.org/user-guide/configuration/#nav

A new "Plugins" page was added to the documentation (https://github.com/arduino/arduino-fwuploader/pull/179). Previously that page it was not included in the `nav` key so the page was not listed in the website's navigation element.

The navigation element before the changes proposed here:

![image](https://github.com/arduino/arduino-fwuploader/assets/8572152/fc0a07be-d402-4f96-84f9-32bb4d6122b0)

and after:

![image](https://github.com/arduino/arduino-fwuploader/assets/8572152/411c9d40-e5ab-4894-9560-5753d24e5a57)
