### PR TITLE
Fix the name not being present on the index

### DIFF
--- a/generator/generator.py
+++ b/generator/generator.py
@@ -289,25 +289,25 @@ def generate_boards_json(input_data, arduino_cli_path, new_boards):
         if fqbn in old_boards:
             boards[fqbn]["loader_sketch"] = create_precomp_sketch_data(simple_fqbn, "loader")
             boards[fqbn]["version_sketch"] = create_precomp_sketch_data(simple_fqbn, "getversion")
+            boards[fqbn].update(create_upload_data(fqbn, installed_cores))
+            # Gets the old_board name
+            res = arduino_cli(
+                cli_path=arduino_cli_path,
+                args=["board", "search", fqbn, "--format", "json"],
+            )
+            for board in json.loads(res):
+                if board["fqbn"] == fqbn:
+                    boards[fqbn]["name"] = board["name"]
+                    break
+
+        else:
+            boards[fqbn]["name"] = data["name"]
 
         for firmware_version in data["versions"]:
             module = data["moduleName"]
             firmware_file = get_firmware_file(module, simple_fqbn, firmware_version)
             boards[fqbn]["firmware"].append(create_firmware_data(firmware_file, module, firmware_version))
             boards[fqbn]["module"] = module
-
-        res = arduino_cli(
-            cli_path=arduino_cli_path,
-            args=["board", "search", fqbn, "--format", "json"],
-        )
-        # Gets the board name
-        for board in json.loads(res):
-            if board["fqbn"] == fqbn:
-                boards[fqbn]["name"] = board["name"]
-                break
-
-        if fqbn in old_boards:
-            boards[fqbn].update(create_upload_data(fqbn, installed_cores))
 
     boards_json = []
     for _, b in boards.items():

--- a/generator/new_boards.json
+++ b/generator/new_boards.json
@@ -1,6 +1,7 @@
 {
   "arduino:renesas_uno:unor4wifi": {
     "moduleName": "ESP32-S3",
-    "versions": ["0.1.0", "0.2.0", "0.2.1"]
+    "versions": ["0.1.0", "0.2.0", "0.2.1"],
+    "name": "Arduino UNO R4 WiFi"
   }
 }


### PR DESCRIPTION
Before this we have to have the core installed to retrieve this info. It's not optimal to install a whole core for a name only.

This problem became clear when running: `arduino-fwuploader firmware list`:
```
Board                       FQBN                                Module     Version
[...]
Arduino MKR WiFi 1010       arduino:samd:mkrwifi1010            NINA     ✔ 1.5.0
[...]
Arduino Uno WiFi Rev2       arduino:megaavr:uno2018             NINA     ✔ 1.5.0  
[...]
Arduino Nano RP2040 Connect arduino:mbed_nano:nanorp2040connect NINA       1.4.8  
Arduino Nano RP2040 Connect arduino:mbed_nano:nanorp2040connect NINA     ✔ 1.5.0  
                            arduino:renesas_uno:unor4wifi       ESP32-S3   0.1.0  
                            arduino:renesas_uno:unor4wifi       ESP32-S3   0.2.0  
                            arduino:renesas_uno:unor4wifi       ESP32-S3 ✔ 0.2.1  
```

Note the missing board name:
This is caused by the absence of this field in the [`plugin_firmware_index.json`](https://downloads.arduino.cc/arduino-fwuploader/boards/plugin_firmware_index.json).
This PR aims to add this info directly without needing to install the whole core