### PR TITLE
Fix Improper Certificate Validation

### DIFF
--- a/certificates/certutils.go
+++ b/certificates/certutils.go
@@ -32,7 +32,7 @@ import (
 // required to connect to that server from the TLS handshake response.
 func ScrapeRootCertificatesFromURL(URL string) (*x509.Certificate, error) {
 	conn, err := tls.Dial("tcp", URL, &tls.Config{
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: false,
 	})
 	if err != nil {
 		logrus.Error(err)


### PR DESCRIPTION
Disabling TLS/SSL certificate verification might lead to attack scenarios where an attacker is able to install rouge certificates on the Arduino board. The attacker would need to be within network proximity of the victim to perform the attack.