### PR TITLE
Throw an error when a tool has no compatible flavour with the current OS

### DIFF
--- a/indexes/download/download.go
+++ b/indexes/download/download.go
@@ -45,6 +45,11 @@ import (
 // DownloadTool downloads and returns the path on the local filesystem of a tool
 func DownloadTool(toolRelease *cores.ToolRelease) (*paths.Path, error) {
 	resource := toolRelease.GetCompatibleFlavour()
+	if resource == nil {
+		err := fmt.Errorf("tool %s not available for this OS", toolRelease.String())
+		logrus.Error(err)
+		return nil, err
+	}
 	installDir := globals.FwUploaderPath.Join(
 		"tools",
 		toolRelease.Tool.Name,

--- a/indexes/download/download_test.go
+++ b/indexes/download/download_test.go
@@ -140,3 +140,25 @@ func TestDownloadFirmware(t *testing.T) {
 	require.NotEmpty(t, firmwarePath)
 	require.FileExists(t, firmwarePath.String())
 }
+
+func TestDownloadToolMissingFlavour(t *testing.T) {
+	toolRelease := &cores.ToolRelease{
+		Version: semver.ParseRelaxed("1.7.0-arduino3"),
+		Tool: &cores.Tool{
+			Name: "bossac",
+			Package: &cores.Package{
+				Name: "arduino",
+			},
+		},
+		Flavors: []*cores.Flavor{},
+	}
+	defer os.RemoveAll(globals.FwUploaderPath.String())
+	indexFile := paths.New("testdata/package_index.json")
+	t.Logf("testing with index: %s", indexFile)
+	index, e := packageindex.LoadIndexNoSign(indexFile)
+	require.NoError(t, e)
+	require.NotEmpty(t, index)
+	toolDir, err := DownloadTool(toolRelease)
+	require.Error(t, err)
+	require.Empty(t, toolDir)
+}


### PR DESCRIPTION
The fwuploader currently crashes if a tool is not available for the OS. With this fix, it throws an error instead.