### PR TITLE
Print error message on certificate flash failure

### DIFF
--- a/cli/certificates/flash.go
+++ b/cli/certificates/flash.go
@@ -85,7 +85,7 @@ func runFlash(certificateURLs, certificatePaths []string) {
 	res, flashErr := flashCertificates(uploader, certificateURLs, certificatePaths)
 	feedback.PrintResult(res)
 	if flashErr != nil {
-		os.Exit(int(feedback.ErrGeneric))
+		feedback.Fatal(fmt.Sprintf("Error during certificates flashing: %s", flashErr), feedback.ErrGeneric)
 	}
 }
 


### PR DESCRIPTION
Previously, if there was a problem during the flashing stage of the certificate flash command invocation, Arduino Firmware Uploader would exit silently, giving the user no feedback that something had gone wrong other than a generic exit status 1:

```text
$ touch /tmp/cert-with-unsupported-extension.crt

$ arduino-fwuploader certificates flash --address COM42 --file /tmp/cert-with-unsupported-extension.crt --fqbn arduino:renesas_uno:unor4wifi

Converting and flashing certificate C:/Users/per/AppData/Local/Temp/cert-with-unsupported-extension.crt

$ echo $?

1
```

After the change proposed here, Arduino Firmware Updater clearly communicates to the user that the command failed, and why:

```text
$ arduino-fwuploader certificates flash --address COM42 --file /tmp/cert-with-unsupported-extension.crt --fqbn arduino:renesas_uno:unor4wifi

Converting and flashing certificate C:/Users/per/AppData/Local/Temp/cert-with-unsupported-extension.crt
Error during certificates flashing: cert format .crt not supported, please use .pem or .cer
```