### PR TITLE
Fix wrong scrape of Root Certificates

### DIFF
--- a/certificates/certutils.go
+++ b/certificates/certutils.go
@@ -45,15 +45,15 @@ func ScrapeRootCertificatesFromURL(URL string) (*x509.Certificate, error) {
 		return nil, err
 	}
 
-	peerCertificates := conn.ConnectionState().PeerCertificates
-	if len(peerCertificates) == 0 {
-		err = fmt.Errorf("no peer certificates found at %s", URL)
-		logrus.Error(err)
-		return nil, err
+	chains := conn.ConnectionState().VerifiedChains
+	if len(chains) == 0 {
+		return nil, fmt.Errorf("no certificates found at %s", URL)
 	}
-
-	rootCertificate := peerCertificates[len(peerCertificates)-1]
-	return rootCertificate, nil
+	rootCertificate := chains[len(chains)-1]
+	if len(rootCertificate) == 0 {
+		return nil, fmt.Errorf("no certificates found at %s", URL)
+	}
+	return rootCertificate[len(rootCertificate)-1], nil
 }
 
 // LoadCertificatesFromFile read certificates from the given file. PEM and CER formats

--- a/certificates/certutils.go
+++ b/certificates/certutils.go
@@ -30,7 +30,7 @@ import (
 
 // ScrapeRootCertificatesFromURL downloads from a webserver the root certificate
 // required to connect to that server from the TLS handshake response.
-func ScrapeRootCertificatesFromURL(URL string) (*x509.Certificate, error) {
+func ScrapeRootCertificatesFromURL(URL string) ([]*x509.Certificate, error) {
 	conn, err := tls.Dial("tcp", URL, &tls.Config{
 		InsecureSkipVerify: false,
 	})
@@ -49,11 +49,12 @@ func ScrapeRootCertificatesFromURL(URL string) (*x509.Certificate, error) {
 	if len(chains) == 0 {
 		return nil, fmt.Errorf("no certificates found at %s", URL)
 	}
-	rootCertificate := chains[len(chains)-1]
-	if len(rootCertificate) == 0 {
-		return nil, fmt.Errorf("no certificates found at %s", URL)
+	rootCertificates := make([]*x509.Certificate, len(chains))
+	for i, chain := range chains {
+		// The last certificate of the chain is always the Root Certificate
+		rootCertificates[i] = chain[len(chain)-1]
 	}
-	return rootCertificate[len(rootCertificate)-1], nil
+	return rootCertificates, nil
 }
 
 // LoadCertificatesFromFile read certificates from the given file. PEM and CER formats

--- a/certificates/certutils_test.go
+++ b/certificates/certutils_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestScrapeRootCertificatesFromURL(t *testing.T) {
-	cert, err := certificates.ScrapeRootCertificatesFromURL("www.arduino.cc:443")
+	rootCerts, err := certificates.ScrapeRootCertificatesFromURL("www.arduino.cc:443")
 	require.NoError(t, err)
-	require.Equal(t, cert.Issuer, cert.Subject)
+	for _, cert := range rootCerts {
+		require.Equal(t, cert.Issuer, cert.Subject)
+	}
 }

--- a/certificates/certutils_test.go
+++ b/certificates/certutils_test.go
@@ -1,0 +1,14 @@
+package certificates_test
+
+import (
+	"testing"
+
+	"github.com/arduino/arduino-fwuploader/certificates"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScrapeRootCertificatesFromURL(t *testing.T) {
+	cert, err := certificates.ScrapeRootCertificatesFromURL("www.arduino.cc:443")
+	require.NoError(t, err)
+	require.Equal(t, cert.Issuer, cert.Subject)
+}

--- a/cli/certificates/flash.go
+++ b/cli/certificates/flash.go
@@ -121,11 +121,11 @@ func flashCertificates(uploader *plugin.FwUploader, certificateURLs, certificate
 	for _, URL := range certificateURLs {
 		logrus.Infof("Converting and flashing certificate from %s", URL)
 		stdout.Write([]byte(fmt.Sprintf("Converting and flashing certificate from %s\n", URL)))
-		rootCert, err := certificates.ScrapeRootCertificatesFromURL(URL)
+		rootCerts, err := certificates.ScrapeRootCertificatesFromURL(URL)
 		if err != nil {
 			return nil, err
 		}
-		allCerts = append(allCerts, rootCert)
+		allCerts = append(allCerts, rootCerts...)
 	}
 
 	f, err := certsBundle.Create()

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -94,11 +94,8 @@ Error: reboot mode: upload commands sketch: setting DTR to OFF
 
 #### I flashed the certificates, but I am unable to reach the host
 
-The **whole certificate chain** is needed to make it work. Using
-[`-u` flags](commands/arduino-fwuploader_certificates_flash.md#options) (ex: `-u www.arduino.cc:443`) won’t work because
-it only downloads the root certificates. The solution is to use only the
-[`-f` flag](commands/arduino-fwuploader_certificates_flash.md#options) and provide a pem certificate containing the
-whole chain.
+There was a bug in the arduino-fwuploader prior `2.4.1` which didn't pick the actual root certificate. Upgrading to the
+latest version solves the problem.
 
 #### My antivirus says that `espflash` is a threat
 


### PR DESCRIPTION
After #212 we can leverage the usage of [ConnectionState.VerifiedChains](https://pkg.go.dev/crypto/tls@go1.21.0#ConnectionState) and per docs:
> last element is from Config.RootCAs

So the last element of the VerifiedChains will be the actual RootCA!