### PR TITLE
use OIDC to retrieve the credentials, fixup for #240

### DIFF
--- a/.github/workflows/generate-index.yml
+++ b/.github/workflows/generate-index.yml
@@ -1,5 +1,9 @@
 name: Generate Index
 
+env:
+  PROJECT_NAME: arduino-fwuploader
+  AWS_REGION: "us-east-1"
+
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
@@ -66,11 +70,16 @@ jobs:
       - name: create the gzip
         run: gzip --keep boards/plugin_firmware_index.json
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: "github_${{ env.PROJECT_NAME }}"
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: s3 sync
         run: |
-          aws s3 sync boards/ s3://${{ secrets.DOWNLOADS_BUCKET }}/arduino-fwuploader/boards
-          aws s3 sync firmwares/ s3://${{ secrets.DOWNLOADS_BUCKET }}/arduino-fwuploader/firmwares
+          aws s3 sync boards/ s3://${{ secrets.DOWNLOADS_BUCKET }}/${{ env.PROJECT_NAME }}/boards
+          aws s3 sync firmwares/ s3://${{ secrets.DOWNLOADS_BUCKET }}/${{ env.PROJECT_NAME }}/firmwares
         env:
-          AWS_REGION: "us-east-1" # or https://github.com/aws/aws-cli/issues/5623
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ env.AWS_REGION }} # or https://github.com/aws/aws-cli/issues/5623


### PR DESCRIPTION
While carrying on #240 I forgot to update this workflow. Now it uses OIDC to retrieve the short-lived credential like the release one.