### PR TITLE
Refactor variables in release workflows

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -79,7 +79,7 @@ jobs:
 
   build:
     needs: package-name-prefix
-    name: Build ${{ matrix.os.name }}
+    name: Build ${{ matrix.os.artifact-name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -89,31 +89,31 @@ jobs:
         os:
           - task: Windows_32bit
             path: "*Windows_32bit.zip"
-            name: Windows_X86-32
+            artifact-name: Windows_X86-32
           - task: Windows_64bit
             path: "*Windows_64bit.zip"
-            name: Windows_X86-64
+            artifact-name: Windows_X86-64
           - task: Linux_32bit
             path: "*Linux_32bit.tar.gz"
-            name: Linux_X86-32
+            artifact-name: Linux_X86-32
           - task: Linux_64bit
             path: "*Linux_64bit.tar.gz"
-            name: Linux_X86-64
+            artifact-name: Linux_X86-64
           - task: Linux_ARMv6
             path: "*Linux_ARMv6.tar.gz"
-            name: Linux_ARMv6
+            artifact-name: Linux_ARMv6
           - task: Linux_ARMv7
             path: "*Linux_ARMv7.tar.gz"
-            name: Linux_ARMv7
+            artifact-name: Linux_ARMv7
           - task: Linux_ARM64
             path: "*Linux_ARM64.tar.gz"
-            name: Linux_ARM64
+            artifact-name: Linux_ARM64
           - task: macOS_64bit
             path: "*macOS_64bit.tar.gz"
-            name: macOS_64
+            artifact-name: macOS_64
           - task: macOS_ARM64
             path: "*macOS_ARM64.tar.gz"
-            name: macOS_ARM64
+            artifact-name: macOS_ARM64
 
     steps:
       - name: Checkout repository
@@ -141,7 +141,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: ${{ env.DIST_DIR }}/${{ matrix.os.path }}
-          name: ${{ matrix.os.name }}
+          name: ${{ matrix.os.artifact-name }}
 
   checksums:
     needs:

--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        os:
+        task:
           - Windows_32bit
           - Windows_64bit
           - Linux_32bit
@@ -45,7 +45,7 @@ jobs:
 
       - name: Create changelog
         # Avoid creating the same changelog for each os
-        if: matrix.os == 'Windows_32bit'
+        if: matrix.task == 'Windows_32bit'
         uses: arduino/create-changelog@v1
         with:
           tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
@@ -65,7 +65,7 @@ jobs:
           version: 3.x
 
       - name: Build
-        run: task dist:${{ matrix.os }}
+        run: task dist:${{ matrix.task }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -75,7 +75,7 @@ jobs:
           path: ${{ env.DIST_DIR }}
 
   notarize-macos:
-    name: Notarize ${{ matrix.artifact.name }}
+    name: Notarize ${{ matrix.build.folder-suffix }}
     runs-on: macos-latest
     needs: create-release-artifacts
     permissions:
@@ -86,11 +86,11 @@ jobs:
 
     strategy:
       matrix:
-        artifact:
-          - name: darwin_amd64
-            path: "macOS_64bit.tar.gz"
-          - name: darwin_arm64
-            path: "macOS_ARM64.tar.gz"
+        build:
+          - folder-suffix: darwin_amd64
+            package-suffix: "macOS_64bit.tar.gz"
+          - folder-suffix: darwin_arm64
+            package-suffix: "macOS_ARM64.tar.gz"
 
     steps:
       - name: Checkout repository
@@ -136,7 +136,7 @@ jobs:
         run: |
           cat > "${{ env.GON_CONFIG_PATH }}" <<EOF
           # See: https://github.com/Bearer/gon#configuration-file
-          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"]
+          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
 
           sign {
@@ -165,11 +165,11 @@ jobs:
         run: |
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"
+          chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"
           TAG="${GITHUB_REF/refs\/tags\//}"
-          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.artifact.path }}"
+          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}"
           tar -czvf "$PACKAGE_FILENAME" \
-          -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/" "${{ env.PROJECT_NAME }}" \
+          -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 

--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -93,6 +93,11 @@ jobs:
             package-suffix: "macOS_ARM64.tar.gz"
 
     steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -136,7 +141,7 @@ jobs:
         run: |
           cat > "${{ env.GON_CONFIG_PATH }}" <<EOF
           # See: https://github.com/Bearer/gon#configuration-file
-          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"]
+          source = ["${{ env.DIST_DIR }}/${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
 
           sign {
@@ -165,11 +170,11 @@ jobs:
         run: |
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"
+          chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
           TAG="${GITHUB_REF/refs\/tags\//}"
           PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}"
           tar -czvf "$PACKAGE_FILENAME" \
-          -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/" "${{ env.PROJECT_NAME }}" \
+          -C "${{ env.BUILD_FOLDER }}/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 

--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -97,6 +97,8 @@ jobs:
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >> "$GITHUB_ENV"
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          echo "PACKAGE_FILENAME=${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -171,12 +173,9 @@ jobs:
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
-          TAG="${GITHUB_REF/refs\/tags\//}"
-          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}"
-          tar -czvf "$PACKAGE_FILENAME" \
+          tar -czvf "${{ env.PACKAGE_FILENAME }}" \
           -C "${{ env.BUILD_FOLDER }}/" "${{ env.PROJECT_NAME }}" \
           -C ../../ LICENSE.txt
-          echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
GitHub Actions workflows are used to automatically generate beta tester and production builds of the project.

While starting the work to update the workflow code for compatibility with the breaking change introduced in the latest versions of the **actions/upload-artifact** action (https://github.com/arduino/arduino-fwuploader/pull/233), I found that it was quite difficult to follow the workflow code due to the way some variables were defined. The refactoring proposed here is intended to improve the maintainability and readability of the workflows:

## Use more meaningful variable names

A separate build is generated for each of the target host types. This is done using a job matrix, which creates a parallel run of the workflow job for each target. The matrix defines variables that provide the data that is specific to each job.

The variable names used previously did not clearly communicate their nature:

- The variable for the task name was named "os"
- The variables for the build filename components used the term "artifact", which is ambiguous in this context where the term is otherwise used to refer to the completely unrelated workflow artifacts

These variable names made it very difficult for anyone not intimately familiar with the workings of the workflow to understand its code.

## Use workflow environment variables to reduce code duplication

Multiple commands in the notarization step of the "Release" workflow include the path of the folder that contains the build output, and the filename of the package.

Previously, there was some code duplication and inconsistency in how these were referenced.

This is improved on through the consistent use of workflow environment variables.

## Reviewer notes

In order to validate the changes proposed here, I made a dummy release in my fork using a certificate from my own personal Apple Developer Program account for the notarization:

https://github.com/per1234/arduino-fwuploader/actions/runs/11286313009

https://github.com/per1234/arduino-fwuploader/releases/tag/0.0.0-rc.10