### PR TITLE
Add missing schedule trigger to workflow

### DIFF
--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -30,6 +30,9 @@ on:
       - "poetry.lock"
       - "pyproject.toml"
       - "tests/**"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 10 * * WED"
   workflow_dispatch:
   repository_dispatch:
 


### PR DESCRIPTION
The integration tests run automatically via a GitHub Actions workflow.

The workflows are typically configured to run whenever any relevant file in the repository is changed. However, the results of the workflow run are also dependent on the external environment it runs in, which include:

- The software running on the GitHub hosted GitHub Actions runner machines
- The GitHub Actions actions used by the workflow
- The dependencies that are installed by the workflow directly or via the GitHub Actions actions it uses

The workflows don't always fully pin dependencies. This was done in the interest on reducing the maintenance burden of keeping the systems up to date. However, it also means that a new release of a dependency can cause the workflow runs to start failing (which might happen through an enhancement to that resource resolving a false negative, or a defect causing a false negative).

When the repository file path trigger is used by itself, this sort of external breakage is only revealed when an unrelated change triggers the workflow. That can be distracting even to a dedicated member of the project development team, as well as confusing and discouraging to any contributor.

This type of change can be caught by adding a `schedule` event trigger that causes the workflow to run periodically in addition to the other on-demand triggers. This allows the problem to be identified and resolved at the maintainer's convenience, separate from the unrelated development work.