### PR TITLE
Bring files into compliance with latest Prettier formatting style

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ For guidance on installation and development, see the [User documentation]
 
 ## Security
 
-If you think you found a vulnerability or other security-related bug in this project, please read our [security policy]
-and report the bug to our Security Team 🛡️ Thank you!
+If you think you found a vulnerability or other security-related bug in this project, please read our [security policy] and
+report the bug to our Security Team 🛡️ Thank you!
 
 e-mail contact: security@arduino.cc
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -8,9 +8,8 @@ Uploader.
 
 ## MKR Vidor 4000
 
-The [Arduino MKR Vidor 4000] has been deprecated during the migration to the [plugin] system because the board has
-reached it's EOL state. If you wish to update the firmware it's still possible by using version [2.3.0] of the Arduino
-Firmware Uploader.
+The [Arduino MKR Vidor 4000] has been deprecated during the migration to the [plugin] system because the board has reached
+it's EOL state. If you wish to update the firmware it's still possible by using version [2.3.0] of the Arduino Firmware Uploader.
 
 [Arduino MKR 1000]: https://docs.arduino.cc/hardware/mkr-1000-wifi
 [Arduino MKR Vidor 4000]: https://docs.arduino.cc/hardware/mkr-vidor-4000


### PR DESCRIPTION
The Prettier tool is used to format the project's Markdown files. Prettier's word wrapping system seems to have changed in a recent release. This caused the "Check Prettier Formatting" GitHub Actions workflow to start failing due to the formatting of some Markdown files no longer being in compliance with the Prettier formatting style.