### PR TITLE
Use maintained fork of "setup-licensed" action in dependency license check workflow

### DIFF
--- a/.github/workflows/check-go-dependencies-task.yml
+++ b/.github/workflows/check-go-dependencies-task.yml
@@ -72,14 +72,14 @@ jobs:
         with:
           submodules: recursive
 
-      # This is required to allow jonabc/setup-licensed to install licensed via Ruby gem.
+      # This is required to allow licensee/setup-licensed to install licensed via Ruby gem.
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby # Install latest version
 
       - name: Install licensed
-        uses: jonabc/setup-licensed@v1
+        uses: licensee/setup-licensed@v1.3.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -131,14 +131,14 @@ jobs:
         with:
           submodules: recursive
 
-      # This is required to allow jonabc/setup-licensed to install licensed via Ruby gem.
+      # This is required to allow licensee/setup-licensed to install licensed via Ruby gem.
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby # Install latest version
 
       - name: Install licensed
-        uses: jonabc/setup-licensed@v1
+        uses: licensee/setup-licensed@v1.3.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x


### PR DESCRIPTION
This GitHub Actions action is used by the dependency license check workflow to install the [**Licensed**](https://github.com/licensee/licensed) tool in the runner workspace.

The action has a convoluted history of ownership: the repository was originally owned by GitHub user [`jonabc`](https://github.com/jonabc). It was later transferred to the [`github`](https://github.com/github) organization. Then GitHub abandoned the project, archiving the repository. The [`licensee`](https://github.com/licensee) organization has now created a hard fork of the action, which is recommended in [the readme of the `github/setup-licensed` repository](https://github.com/github/setup-licensed#setup-licensed).

The `licensee` organization has also taken over the management of the **Licensed** tool, and their [`licensee`](https://github.com/licensee/licensee) Ruby gem is a significant dependency of "Licensed". So they will be best equipped to maintain the action going forward.

The workflow is hereby updated to use the now canonical **licensee/setup-licensed** action.

The "licensee/setup-licensed" action maintainers have not provided a [major version ref](https://docs.github.com/actions/sharing-automations/creating-actions/about-custom-actions#good-practices-for-release-management) (https://github.com/licensee/setup-licensed/issues/13), so it is necessary to pin the action to the latest release tag.