### PR TITLE
Update format of dependency license metadata

### DIFF
--- a/.licenses/arduino-fwuploader/go/github.com/mattn/go-colorable.dep.yml
+++ b/.licenses/arduino-fwuploader/go/github.com/mattn/go-colorable.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/mattn/go-colorable
 version: v0.1.8
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/mattn/go-colorable
 license: mit
 licenses:

--- a/.licenses/arduino-fwuploader/go/go.bug.st/cleanup.dep.yml
+++ b/.licenses/arduino-fwuploader/go/go.bug.st/cleanup.dep.yml
@@ -2,7 +2,7 @@
 name: go.bug.st/cleanup
 version: v1.0.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/go.bug.st/cleanup
 license: bsd-3-clause
 licenses:
@@ -42,3 +42,4 @@ licenses:
     POSSIBILITY OF SUCH DAMAGE.
 
 notices: []
+...

--- a/.licenses/arduino-fwuploader/go/go.bug.st/downloader/v2.dep.yml
+++ b/.licenses/arduino-fwuploader/go/go.bug.st/downloader/v2.dep.yml
@@ -2,7 +2,7 @@
 name: go.bug.st/downloader/v2
 version: v2.1.1
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/go.bug.st/downloader/v2
 license: bsd-3-clause
 licenses:
@@ -42,3 +42,4 @@ licenses:
     POSSIBILITY OF SUCH DAMAGE.
 
 notices: []
+...

--- a/.licenses/arduino-fwuploader/go/google.golang.org/protobuf/internal/encoding/json.dep.yml
+++ b/.licenses/arduino-fwuploader/go/google.golang.org/protobuf/internal/encoding/json.dep.yml
@@ -2,7 +2,7 @@
 name: google.golang.org/protobuf/internal/encoding/json
 version: v1.33.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/google.golang.org/protobuf/internal/encoding/json
 license: bsd-3-clause
 licenses:

--- a/.licenses/arduino-fwuploader/go/google.golang.org/protobuf/internal/impl.dep.yml
+++ b/.licenses/arduino-fwuploader/go/google.golang.org/protobuf/internal/impl.dep.yml
@@ -2,7 +2,7 @@
 name: google.golang.org/protobuf/internal/impl
 version: v1.33.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/google.golang.org/protobuf/internal/impl
 license: bsd-3-clause
 licenses:

--- a/.licenses/arduino-fwuploader/go/google.golang.org/protobuf/types/descriptorpb.dep.yml
+++ b/.licenses/arduino-fwuploader/go/google.golang.org/protobuf/types/descriptorpb.dep.yml
@@ -2,7 +2,7 @@
 name: google.golang.org/protobuf/types/descriptorpb
 version: v1.33.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/google.golang.org/protobuf/types/descriptorpb
 license: bsd-3-clause
 licenses:

--- a/.licenses/arduino-fwuploader/go/google.golang.org/protobuf/types/known/wrapperspb.dep.yml
+++ b/.licenses/arduino-fwuploader/go/google.golang.org/protobuf/types/known/wrapperspb.dep.yml
@@ -2,7 +2,7 @@
 name: google.golang.org/protobuf/types/known/wrapperspb
 version: v1.33.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/google.golang.org/protobuf/types/known/wrapperspb
 license: bsd-3-clause
 licenses:


### PR DESCRIPTION
The [**Licensed**](https://github.com/licensee/licensed) tool is used to check for incompatible licenses in the project dependencies. The tool relies on a cache of metadata stored in the repository.

An older version of **Licensed** was in use at the time the cache was established. There are some minor differences in the format of the metadata generated by the version of **Licensed** currently in use.


## Trailing Whitespace

Previous versions of this tool added a trailing space on the `summary` key. Although trailing whitespace in human produced content is not permitted, machine generated content is used as-is, and so these trailing spaces were left in the metadata files.

It seems that the defect in the "Licensed" tool that caused the trailing space was fixed in a recent version because it is now absent in the metadata files produced by the tool.

## YAML Document End Markers

The version of the tool now in use adds YAML document end markers to some metadata files, which were not present in the files generated by the tool at the time the cache was established.

I don't know why it adds these markers to only some of the metadata files, but they are valid (though optional so the files without are also correct) and machine generated content is used as-is.

---

Even though there is no technical significance to the format differences, they are disruptive in that they result in irrelevant diffs in specific metadata files when they are regenerated after a dependency bump. Rather than dealing with these diffs over time, it will be best to instead update the metadata to the new format comprehensively.