### PR TITLE
Use `engines.node` as source of version data for "actions/setup-node" action

### DIFF
--- a/.github/workflows/check-markdown-task.yml
+++ b/.github/workflows/check-markdown-task.yml
@@ -4,8 +4,6 @@ name: Check Markdown
 env:
   # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.18"
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
 
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
@@ -79,7 +77,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Initialize markdownlint-cli problem matcher
         uses: xt0rted/markdownlint-problem-matcher@v3
@@ -112,7 +110,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-prettier-formatting-task.md
 name: Check Prettier Formatting
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 16.x
-
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   create:
@@ -245,7 +241,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install Task
         uses: arduino/setup-task@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
         "markdown-link-check": "^3.12.1",
         "markdownlint-cli": "^0.37.0",
         "prettier": "^3.3.3"
+      },
+      "engines": {
+        "node": "16.x"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
     "markdown-link-check": "^3.12.1",
     "markdownlint-cli": "^0.37.0",
     "prettier": "^3.3.3"
+  },
+  "engines": {
+    "node": "16.x"
   }
 }


### PR DESCRIPTION
A single standardized version of Node.js is used for all development work in this repository, both by contributors and the automated validation systems.

The **actions/setup-node** GitHub Actions action is used to set up Node.js in the GitHub Actions runner machine.

The action supports obtaining the Node.js version to set up from the `engines.node` key of the `package.json` file:

https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file

This allows us to define the standardized version of Node.js for use with this project in a single place, rather than having to maintain multiple instances of that data.
