### PR TITLE
Bump project Node.js version to 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "prettier": "^3.3.3"
       },
       "engines": {
-        "node": "16.x"
+        "node": "24.x"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "prettier": "^3.3.3"
   },
   "engines": {
-    "node": "16.x"
+    "node": "24.x"
   }
 }


### PR DESCRIPTION
npm package-based tools are used for various development and maintenance operations for this project. In order to ensure these operations work as expected, the project is configured for a specific major version of Node.js to be used by the infrastructure systems and collaborators.

The standard Node.js version for Arduino Tooling projects is now 24.