### PR TITLE
Update preflashed certificate bundle link

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -85,7 +85,7 @@ previous certificates are going to be erased. To overcome this it's required to 
 ```
 
 You can find the certificates that are preflashed on the NINA module
-[here](https://github.com/arduino/nina-fw/blob/master/data/roots.pem).
+[here](https://github.com/arduino/nina-fw/blob/master/data/cacrt_all.pem).
 
 ### Command line options
 


### PR DESCRIPTION
The certificate bundle file hosted in the `arduino/nina-fw` repository has been replaced by a different file with a different name: https://github.com/arduino/nina-fw/pull/104.

That change broke the link to the certificate bundle. The link is hereby updated to point to the current file.

---

Originally reported by @ninora:

https://forum.arduino.cc/t/wifinina-tls-fails-to-local-server-after-cert-upload/1449493/5